### PR TITLE
Make license toml entry optional during 1.16.1

### DIFF
--- a/patches/minecraft/net/minecraft/block/PoweredRailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/PoweredRailBlock.java.patch
@@ -35,18 +35,17 @@
                    return p_208071_1_.func_175640_z(p_208071_2_) ? true : this.func_176566_a(p_208071_1_, p_208071_2_, blockstate, p_208071_3_, p_208071_4_ + 1);
                 } else {
                    return false;
-@@ -156,6 +162,10 @@
+@@ -156,6 +162,9 @@
              return p_185499_1_.func_206870_a(field_176568_b, RailShape.SOUTH_EAST);
           case NORTH_EAST:
              return p_185499_1_.func_206870_a(field_176568_b, RailShape.SOUTH_WEST);
-+         //Forge fix: MC-196102
-+         case NORTH_SOUTH:
++         case NORTH_SOUTH: //Forge fix: MC-196102
 +         case EAST_WEST:
 +            return p_185499_1_;
           }
        case COUNTERCLOCKWISE_90:
           switch((RailShape)p_185499_1_.func_177229_b(field_176568_b)) {
-@@ -255,4 +265,8 @@
+@@ -255,4 +264,8 @@
     protected void func_206840_a(StateContainer.Builder<Block, BlockState> p_206840_1_) {
        p_206840_1_.func_206894_a(field_176568_b, field_176569_M);
     }

--- a/patches/minecraft/net/minecraft/block/RailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/RailBlock.java.patch
@@ -1,11 +1,10 @@
 --- a/net/minecraft/block/RailBlock.java
 +++ b/net/minecraft/block/RailBlock.java
-@@ -49,6 +49,10 @@
+@@ -49,6 +49,9 @@
              return p_185499_1_.func_206870_a(field_176565_b, RailShape.SOUTH_EAST);
           case NORTH_EAST:
              return p_185499_1_.func_206870_a(field_176565_b, RailShape.SOUTH_WEST);
-+             //Forge fix: MC-196102
-+         case NORTH_SOUTH:
++         case NORTH_SOUTH: //Forge fix: MC-196102
 +         case EAST_WEST:
 +            return p_185499_1_;
           }

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -20,6 +20,8 @@
 package net.minecraftforge.fml.loading.moddiscovery;
 
 import com.electronwill.nightconfig.core.UnmodifiableConfig;
+
+import net.minecraftforge.fml.loading.StringSubstitutor;
 import net.minecraftforge.fml.loading.StringUtils;
 import net.minecraftforge.forgespi.language.IConfigurable;
 import net.minecraftforge.forgespi.language.IModFileInfo;
@@ -62,8 +64,16 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
         this.modLoaderVersion = config.<String>getConfigElement("loaderVersion")
                 .map(MavenVersionAdapter::createFromVersionSpec)
                 .orElseThrow(()->new InvalidModFileException("Missing ModLoader version in file", this));
+        String mcVersion = StringSubstitutor.replace("${global.mcVersion}", null);
+        if ("1.16.1".equals(mcVersion)) {
+            this.license = config.<String>getConfigElement("license").orElse("All Rights Reserved (Default License, Modder Please specify)");
+        } else {
+            throw new IllegalStateException("Code exists that should not in " + mcVersion + " Delete other case.");
+        }
+        /* Make license non-optional in >1.16.1, delete the above if, and uncomment the below lines when updating.
         this.license = config.<String>getConfigElement("license")
-                .orElseThrow(()->new InvalidModFileException("Missing License, please supply a license.", this));
+            .orElseThrow(()->new InvalidModFileException("Missing License, please supply a license.", this));
+         */
         this.showAsResourcePack = config.<Boolean>getConfigElement("showAsResourcePack").orElse(false);
         this.properties = config.<UnmodifiableConfig>getConfigElement("properties").
                 map(UnmodifiableConfig::valueMap).orElse(Collections.emptyMap());

--- a/src/fmllauncher/resources/minecraftmod.toml
+++ b/src/fmllauncher/resources/minecraftmod.toml
@@ -1,6 +1,6 @@
 modLoader="minecraft"
 loaderVersion="1"
-license="Mojang all rights reserved"
+license="Mojang Studios, All Rights Reserved"
 [[mods]]
     modId="minecraft"
     version="${global.mcVersion}"


### PR DESCRIPTION
There are to many existing mods to make this required.
Yes, we are technically before a RB and can do breaking changes. However this is too large.